### PR TITLE
fix(charts): update CSV load paths for gh pages

### DIFF
--- a/charts/au_pie_chart.js
+++ b/charts/au_pie_chart.js
@@ -1,4 +1,4 @@
-d3.csv("data/au_genres.csv").then((data) => {
+d3.csv("./data/au_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/au_pie_real.js
+++ b/charts/au_pie_real.js
@@ -1,4 +1,4 @@
-d3.csv("data/au_genres.csv").then((data) => {
+d3.csv("./data/au_genres.csv").then((data) => {
   for (let d of data) {
     if (d.weight < 5) {
       d.weight = 0;

--- a/charts/br_pie_chart.js
+++ b/charts/br_pie_chart.js
@@ -1,4 +1,4 @@
-d3.csv("data/br_genres.csv").then((data) => {
+d3.csv("./data/br_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/ca_pie_chart.js
+++ b/charts/ca_pie_chart.js
@@ -1,4 +1,4 @@
-d3.csv("data/ca_genres.csv").then((data) => {
+d3.csv("./data/ca_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/chart2.js
+++ b/charts/chart2.js
@@ -26,7 +26,7 @@ var yAxis = svg.append("g").attr("class", "myYaxis");
 // A function that create / update the plot for a given variable:
 function update(selectedVar) {
   // Parse the Data
-  d3.csv("data/features_by_playlist_transposed.csv").then((data) => {
+  d3.csv("./data/features_by_playlist_transposed.csv").then((data) => {
     console.log(data);
     // X axis
     x.domain(

--- a/charts/chart3.js
+++ b/charts/chart3.js
@@ -1,6 +1,6 @@
 //Features by year
 
-d3.csv("data/energy_by_year_og.csv").then((data) => {
+d3.csv("./data/energy_by_year_og.csv").then((data) => {
   let chart = LineChart(data, {
     x: (d) => d.year,
     y: (d) => d.energy,

--- a/charts/chart4.js
+++ b/charts/chart4.js
@@ -1,4 +1,4 @@
-d3.csv("data/us_genres.csv").then((data) => {
+d3.csv("./data/us_genres.csv").then((data) => {
   for (let d of data) {
     if (d.weight < 5) {
       d.weight = 0;

--- a/charts/chart5.js
+++ b/charts/chart5.js
@@ -1,4 +1,4 @@
-d3.csv("data/new_us_genres.csv").then((data) => {
+d3.csv("./data/new_us_genres.csv").then((data) => {
   for (let d of data) {
     if (d.avg_streams < 15000000) {
       d.avg_streams = 0;

--- a/charts/de_pie_chart.js
+++ b/charts/de_pie_chart.js
@@ -1,4 +1,4 @@
-d3.csv("data/de_genres.csv").then((data) => {
+d3.csv("./data/de_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/fr_pie_chart.js
+++ b/charts/fr_pie_chart.js
@@ -1,4 +1,4 @@
-d3.csv("data/fr_genres.csv").then((data) => {
+d3.csv("./data/fr_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/gb_pie_chart.js
+++ b/charts/gb_pie_chart.js
@@ -1,4 +1,4 @@
-d3.csv("data/gb_genres.csv").then((data) => {
+d3.csv("./data/gb_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/jp_pie_chart.js
+++ b/charts/jp_pie_chart.js
@@ -1,4 +1,4 @@
-d3.csv("data/jp_genres.csv").then((data) => {
+d3.csv("./data/jp_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/stacked_bar.js
+++ b/charts/stacked_bar.js
@@ -1,4 +1,4 @@
-d3.csv("data/new_genres.csv").then((data) => {
+d3.csv("./data/new_genres.csv").then((data) => {
   let chart = StackedBarChart(data, {
     x: (d) => d.genre,
     y: (d) => d.avg_streams / 1e6,

--- a/charts/us_donut.js
+++ b/charts/us_donut.js
@@ -1,4 +1,4 @@
-d3.csv("data/us_genres.csv").then((data) => {
+d3.csv("./data/us_genres.csv").then((data) => {
   //   for (let d of data) {
   //     if (d.weight < 5) {
   //       d.weight = 0;

--- a/charts/us_pie_chart.js
+++ b/charts/us_pie_chart.js
@@ -1,6 +1,6 @@
 //Features by year
 
-d3.csv("data/us_genres.csv").then((data) => {
+d3.csv("./data/us_genres.csv").then((data) => {
   for (let d of data) {
     if (d.weight < 5) {
       d.weight = 0;

--- a/charts/us_pie_chart_80s.js
+++ b/charts/us_pie_chart_80s.js
@@ -1,6 +1,6 @@
 //Features by year
 
-d3.csv("data/us_genres_80s.csv").then((data) => {
+d3.csv("./data/us_genres_80s.csv").then((data) => {
   for (let d of data) {
     if (d.weight < 5) {
       d.weight = 0;


### PR DESCRIPTION
This patch updates the chart CSV load paths to work with GitHub Pages. By default, GitHub Pages deploys to the user's `username.github.io` and will put repositories underneath their repository name. Thus, when `d3` tries to fetch the CSV, I need to specify that it should start from the current path (i.e. `/music-analysis`) and not from the root path.

_**Update:** This may actually not be necessary. I may have been inspecting an old GitHub Pages deployment. It seems what is on `main` is working as expected. If it does ever stop working, however, this may be a solution._